### PR TITLE
feat: list messages tool

### DIFF
--- a/app/Mcp/Servers/NunoNationChat.php
+++ b/app/Mcp/Servers/NunoNationChat.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Mcp\Servers;
 
+use App\Mcp\Tools\GetMessagesTool;
 use App\Mcp\Tools\SendMessageTool;
 use Laravel\Mcp\Server;
 
@@ -39,6 +40,7 @@ final class NunoNationChat extends Server
      */
     protected array $tools = [
         SendMessageTool::class,
+        GetMessagesTool::class,
     ];
 
     /**

--- a/app/Mcp/Tools/GetMessagesTool.php
+++ b/app/Mcp/Tools/GetMessagesTool.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mcp\Tools;
+
+use App\Models\Message;
+use Illuminate\JsonSchema\JsonSchema;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Tool;
+
+final class GetMessagesTool extends Tool
+{
+    /**
+     * The tool's description.
+     */
+    protected string $description = <<<'MARKDOWN'
+        Use this tool to get the latest messages from the "Nuno Nation Chat" server.
+
+        Default to retrieving 50 messages if no limit is specified.
+        MARKDOWN;
+
+    /**
+     * Handle the tool request.
+     */
+    public function handle(Request $request): Response
+    {
+        $request->validate([
+            'limit' => 'nullable|integer|min:1|max:100',
+        ]);
+
+        $limit = $request->integer('limit', 50);
+
+        $messages = Message::query()
+            ->latest()
+            ->limit($limit)
+            ->get();
+
+        $formattedMessages = $messages->map(fn (Message $message): string => sprintf(
+            '- **%s**: %s',
+            $message->name,
+            $message->body,
+        ))->join("\n");
+
+        return Response::text(<<<MARKDOWN
+            Here are the latest messages from the "Nuno Nation Chat" server:
+
+            $formattedMessages
+            MARKDOWN);
+    }
+
+    /**
+     * Get the tool's input schema.
+     *
+     * @return array<string, JsonSchema>
+     *
+     * @codeCoverageIgnore
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'limit' => $schema->integer()
+                ->min(1)
+                ->max(100)
+                ->default(50)
+                ->description('The number of messages to retrieve.'),
+        ];
+    }
+}

--- a/app/Mcp/Tools/SendMessageTool.php
+++ b/app/Mcp/Tools/SendMessageTool.php
@@ -20,6 +20,19 @@ final class SendMessageTool extends Tool
         MARKDOWN;
 
     /**
+     * The names that should not be used when sending a message.
+     */
+    private array $ignoreableNames = [
+        'User',
+        'Assistant',
+        'Claude',
+        'GPT',
+        'AI',
+        'Bot',
+        'Cursor',
+    ];
+
+    /**
      * Handle the tool request.
      */
     public function handle(Request $request, CreateMessageAction $action): Response
@@ -31,6 +44,16 @@ final class SendMessageTool extends Tool
 
         $name = $request->string('name')->value();
         $body = $request->string('body')->value();
+
+        foreach ($this->ignoreableNames as $ignoreableName) {
+            if (strtolower($name) === strtolower($ignoreableName)) {
+                return Response::error(<<<'MARKDOWN'
+                    You must provide a valid name that is not "User", or "Assistant", or "Claude", or "GPT", or "AI", or "Bot".
+
+                    IMPORTANT: Ask the user for their first name if you don't know it.
+                    MARKDOWN);
+            }
+        }
 
         $action->handle($name, $body);
 

--- a/app/Mcp/Tools/SendMessageTool.php
+++ b/app/Mcp/Tools/SendMessageTool.php
@@ -13,26 +13,24 @@ use Laravel\Mcp\Server\Tool;
 final class SendMessageTool extends Tool
 {
     /**
+     * The names that should not be used when sending a message.
+     */
+    private const array IGNORABLE_NAMES = [
+        'user',
+        'assistant',
+        'claude',
+        'gpt',
+        'ai',
+        'bot',
+        'cursor',
+    ];
+
+    /**
      * The tool's description.
      */
     protected string $description = <<<'MARKDOWN'
         Use this tool to send a message to the "Nuno Nation Chat" server.
         MARKDOWN;
-
-    /**
-     * The names that should not be used when sending a message.
-     *
-     * @var array<int, string>
-     */
-    private array $ignoreableNames = [
-        'User',
-        'Assistant',
-        'Claude',
-        'GPT',
-        'AI',
-        'Bot',
-        'Cursor',
-    ];
 
     /**
      * Handle the tool request.
@@ -47,14 +45,12 @@ final class SendMessageTool extends Tool
         $name = $request->string('name')->value();
         $body = $request->string('body')->value();
 
-        foreach ($this->ignoreableNames as $ignoreableName) {
-            if (mb_strtolower($name) === mb_strtolower((string) $ignoreableName)) {
-                return Response::error(<<<'MARKDOWN'
-                    You must provide a valid name that is not "User", or "Assistant", or "Claude", or "GPT", or "AI", or "Bot".
+        if (in_array(mb_strtolower($name), self::IGNORABLE_NAMES)) {
+            return Response::error(<<<'MARKDOWN'
+                You must provide a valid name that is not "User", "Assistant", "Claude", "GPT", "AI", "Bot", or "Cursor".
 
-                    IMPORTANT: Ask the user for their first name if you don't know it.
-                    MARKDOWN);
-            }
+                IMPORTANT: Ask the user for their first name if you don't know it.
+                MARKDOWN);
         }
 
         $action->handle($name, $body);
@@ -83,7 +79,7 @@ final class SendMessageTool extends Tool
                 ->description(<<<'MARKDOWN'
                     The name of the user sending the message.
 
-                    Don't use "User", or "Assistant", or "Claude", or "GPT", or "AI", or "Bot".
+                    Don't use "User", "Assistant", "Claude", "GPT", "AI", "Bot", or "Cursor".
 
                     IMPORTANT: Ask the user for their first name if you don't know it.
                     MARKDOWN),

--- a/app/Mcp/Tools/SendMessageTool.php
+++ b/app/Mcp/Tools/SendMessageTool.php
@@ -21,6 +21,8 @@ final class SendMessageTool extends Tool
 
     /**
      * The names that should not be used when sending a message.
+     *
+     * @var array<int, string>
      */
     private array $ignoreableNames = [
         'User',
@@ -46,7 +48,7 @@ final class SendMessageTool extends Tool
         $body = $request->string('body')->value();
 
         foreach ($this->ignoreableNames as $ignoreableName) {
-            if (strtolower($name) === strtolower($ignoreableName)) {
+            if (mb_strtolower($name) === mb_strtolower((string) $ignoreableName)) {
                 return Response::error(<<<'MARKDOWN'
                     You must provide a valid name that is not "User", or "Assistant", or "Claude", or "GPT", or "AI", or "Bot".
 

--- a/tests/Feature/Mcp/Tools/GetMessagesToolTest.php
+++ b/tests/Feature/Mcp/Tools/GetMessagesToolTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Mcp\Servers\NunoNationChat;
+use App\Mcp\Tools\GetMessagesTool;
+use App\Models\Message;
+
+it('displays all messages', function () {
+    Message::factory()->create([
+        'name' => 'Emerson Carvalho',
+        'body' => 'Love you twitch!',
+    ]);
+
+    $response = NunoNationChat::tool(GetMessagesTool::class);
+
+    $response->assertOk()->assertSee('Emerson Carvalho');
+});

--- a/tests/Feature/Mcp/Tools/SendMessageToolTest.php
+++ b/tests/Feature/Mcp/Tools/SendMessageToolTest.php
@@ -6,24 +6,6 @@ use App\Mcp\Servers\NunoNationChat;
 use App\Mcp\Tools\SendMessageTool;
 use App\Models\Message;
 
-it('validates the name argument', function () {
-    $response = NunoNationChat::tool(SendMessageTool::class);
-
-    $response->assertHasErrors([
-        'The name field is required.',
-    ]);
-});
-
-it('validates the body argument', function () {
-    $response = NunoNationChat::tool(SendMessageTool::class, [
-        'name' => 'Marc',
-    ]);
-
-    $response->assertHasErrors([
-        'The body field is required.',
-    ]);
-});
-
 it('sends a message', function () {
     $response = NunoNationChat::tool(SendMessageTool::class, [
         'name' => 'Marc',

--- a/tests/Feature/Mcp/Tools/SendMessageToolTest.php
+++ b/tests/Feature/Mcp/Tools/SendMessageToolTest.php
@@ -39,3 +39,14 @@ it('sends a message', function () {
         ->and($message->name)->toBe('Marc')
         ->and($message->body)->toBe('Hello, world!');
 });
+
+it('rejects invalid names', function () {
+    $response = NunoNationChat::tool(SendMessageTool::class, [
+        'name' => 'User',
+        'body' => 'Hello, world!',
+    ]);
+
+    $response->assertHasErrors([
+        'You must provide a valid name',
+    ]);
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve and view recent chat messages with an adjustable limit (default 50, validated 1–100).
* **Bug Fixes**
  * Prevents sending messages using generic/AI-like names (e.g., "User", "Assistant", "Bot", "Cursor"), returning a clear prompt to provide a real first name.
* **Tests**
  * Added tests for viewing recent messages and updated send-message tests to assert rejection of invalid names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->